### PR TITLE
Add HTTPClient to KeycloakConfig

### DIFF
--- a/pkg/ginkeycloak/gin_keycloak.go
+++ b/pkg/ginkeycloak/gin_keycloak.go
@@ -126,7 +126,11 @@ func getPublicKeyFromCacheOrBackend(keyId string, config KeycloakConfig) (KeyEnt
 		u.Path = path.Join(u.Path, "realms", config.Realm, "protocol/openid-connect/certs")
 	}
 
-	resp, err := http.Get(u.String())
+	httpClient := http.DefaultClient
+	if config.HTTPClient != nil {
+		httpClient = config.HTTPClient
+	}
+	resp, err := httpClient.Get(u.String())
 	if err != nil {
 		return KeyEntry{}, err
 	}
@@ -231,6 +235,7 @@ type KeycloakConfig struct {
 	Realm              string
 	FullCertsPath      *string
 	CustomClaimsMapper ClaimMapperFunc
+	HTTPClient *http.Client
 }
 
 func Auth(accessCheckFunction AccessCheckFunction, endpoints KeycloakConfig) gin.HandlerFunc {


### PR DESCRIPTION
Allow specifying an HTTPClient in the KeycloakConfig. This will be used instead of the default client to fetch the token container.

This allows customising the underlying transport to, e.g., add additional TLS CA certs.